### PR TITLE
Allow Bundler 2

### DIFF
--- a/excel-esv.gemspec
+++ b/excel-esv.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "spreadsheet"
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", ">= 1.7"
+  spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
This PR unpins Bundler, to allow Bundler 2 to be used in development and CI.

  - also unpin Rake version